### PR TITLE
added theme props to add class to login, input and link on login prov…

### DIFF
--- a/src/lib/components/ProviderLogin/children/Form/form.presentational.js
+++ b/src/lib/components/ProviderLogin/children/Form/form.presentational.js
@@ -24,7 +24,8 @@ const LoginForm = props => {
     optionToggle,
     btnTxtProvider,
     btnTxtWebId,
-    formButtonText
+    formButtonText,
+    theme
   } = props;
   return (
     <LoginFormWrapper className={`solid-provider-login-component ${className} ${error && 'error'}`}>
@@ -47,17 +48,18 @@ const LoginForm = props => {
             onChange={onChangeInput}
             placeholder={inputPlaholder}
             data-testid="input-webid"
+            className={theme.inputLogin}
           />
         )}
         <SolidLinkButton
           type="button"
-          className="link"
+          className={`link ${theme.linkButton}`}
           onClick={optionToggle}
           data-testid="change-mode-button"
         >
           {withWebId ? btnTxtProvider : btnTxtWebId}
         </SolidLinkButton>
-        <SolidButton type="submit" data-testid="provider-form-button">
+        <SolidButton type="submit" data-testid="provider-form-button" className={theme.buttonLogin}>
           {formButtonText}
         </SolidButton>
       </form>

--- a/src/lib/components/ProviderLogin/provider-login.container.js
+++ b/src/lib/components/ProviderLogin/provider-login.container.js
@@ -13,13 +13,13 @@ import InruptImg from '../../../assets/inrupt_logo.png';
 type Props = {
   providers?: Array<Provider>,
   callbackUri: String,
-  className: String,
   selectPlaceholder?: String,
   inputPlaholder?: String,
   formButtonText?: String,
   btnTxtWebId?: String,
   btnTxtProvider?: String,
-  onError: (error: Error) => void
+  onError: (error: Error) => void,
+  theme?: Object
 };
 
 export default class LoginComponent extends Component<Props> {
@@ -124,6 +124,7 @@ export default class LoginComponent extends Component<Props> {
 
   render() {
     const { error, withWebId } = this.state;
+    const { theme } = this.props;
     return (
       <LoginForm
         {...this.props}
@@ -133,6 +134,7 @@ export default class LoginComponent extends Component<Props> {
         optionToggle={this.optionToggle}
         onChangeInput={this.onChangeInput}
         onSelectChange={this.onProviderSelect}
+        theme={theme}
       />
     );
   }
@@ -165,5 +167,10 @@ LoginComponent.defaultProps = {
       registerLink: 'https://solid.community/register',
       description: 'This is a prototype implementation of a Solid server'
     }
-  ]
+  ],
+  theme: {
+    buttonLogin: '',
+    inputLogin: '',
+    linkButton: ''
+  }
 };


### PR DESCRIPTION
…ider

Now we can add theme prop to provider login to add custom classes for example: 

```js
    theme: {
    buttonLogin: 'customClass',
    inputLogin: 'customClass',
    linkButton: 'customClass'
  }
```