### PR TITLE
Remove changeRaw event handler

### DIFF
--- a/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.component.js
+++ b/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.component.js
@@ -54,7 +54,6 @@ const DateTimePicker = React.memo(
 
     const showTimeSelect = type === UITypes.DateTimeField || type === UITypes.TimeField || false;
     const showTimeSelectOnly = type === UITypes.TimeField || false;
-    const dateFormat = getDateFormat(type);
 
     const updateDate = useCallback(() => {
       const actualValue = formObject[id] || formObject[id] === '' ? formObject[id].value : value;
@@ -65,21 +64,15 @@ const DateTimePicker = React.memo(
     }, [formObject]);
 
     const onChange = useCallback(date => {
-      const obj = { value: date.toString(), ...rest };
+      let obj = {};
+
+      /* User wants to remove the date */
+      if (!date) obj = { value: '', ...rest };
+      else obj = { value: date.toString(), ...rest };
 
       modifyFormObject(id, obj);
       setDate(date);
     });
-
-    const handleChangeRaw = useCallback(
-      date => {
-        const s = document.getElementById(id);
-        s.value = moment(date.target.value).format(dateFormat);
-
-        setInvalid(s.value);
-      },
-      [value, formObject]
-    );
 
     useEffect(() => {
       updateDate();
@@ -157,12 +150,10 @@ const DateTimePicker = React.memo(
                 selected: selectedDate,
                 onChange,
                 ...dateOptions,
-                onChangeRaw: e => handleChangeRaw(e),
                 className: theme && theme.inputText,
                 onBlur,
                 showTimeSelect,
-                showTimeSelectOnly,
-                dateFormat
+                showTimeSelectOnly
               }}
             />
             {invalidate && <ErrorMessage>{invalidate}</ErrorMessage>}


### PR DESCRIPTION
This `handleChangeRaw` event handler was invalidating the component date state when the user tried to manually insert a date instead of using the date picker. Now we default to the component behaviour which is to use the closest possible date to what the user wrote in.