### PR TITLE
Update datepicker to save and read values according to formModel spec

### DIFF
--- a/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.component.js
+++ b/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.component.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { addDays, addSeconds, setHours, setMinutes, format } from 'date-fns';
+import { addDays, addSeconds, setHours, setMinutes, format, isDate } from 'date-fns';
 import * as locales from 'date-fns/locale';
 
 import DatePicker, { registerLocale } from 'react-datepicker';
@@ -9,7 +9,7 @@ import { ErrorMessage } from './date-time.styles';
 
 import { FormModelConfig } from '@context';
 import { UITypes, FormModelUI, DATE_FORMAT } from '@constants';
-import { getLocale, parseInitialValue } from '@utils';
+import { getLocale, parseInitialValue, isValidDate } from '@utils';
 
 const DateTimePicker = React.memo(
   ({ id, value, modifyFormObject, formObject, onSave, autoSave, onBlur, ...rest }) => {
@@ -137,7 +137,7 @@ const DateTimePicker = React.memo(
               {...{
                 id,
                 ...dateOptions,
-                selected: selectedDate,
+                selected: isValidDate(selectedDate) ? selectedDate : null,
                 onChange,
                 className: theme && theme.inputText,
                 onBlur,

--- a/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.component.js
+++ b/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.component.js
@@ -37,6 +37,7 @@ const DateTimePicker = React.memo(
     const type = rest[RDF_TYPE];
 
     useEffect(() => {
+      /* if there is an updated value on the server, use that otherwise use the prop */
       let actualValue = formObject[id] || formObject[id] === '' ? formObject[id].value : value;
       actualValue = parseInitialValue(actualValue, type);
 

--- a/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.component.js
+++ b/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.component.js
@@ -1,16 +1,15 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import DatePicker, { registerLocale } from 'react-datepicker';
-
-import { addDays, addSeconds, setHours, setMinutes } from 'date-fns';
+import { addDays, addSeconds, setHours, setMinutes, format } from 'date-fns';
 import * as locales from 'date-fns/locale';
 
-import { FormModelConfig } from '@context';
-import { UITypes, FormModelUI } from '@constants';
-import { getLocale } from '@utils';
-
+import DatePicker, { registerLocale } from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 
 import { ErrorMessage } from './date-time.styles';
+
+import { FormModelConfig } from '@context';
+import { UITypes, FormModelUI, DATE_FORMAT } from '@constants';
+import { getLocale, parseInitialValue } from '@utils';
 
 const DateTimePicker = React.memo(
   ({ id, value, modifyFormObject, formObject, onSave, autoSave, onBlur, ...rest }) => {
@@ -37,28 +36,32 @@ const DateTimePicker = React.memo(
     const label = rest[UI_LABEL] || '';
     const type = rest[RDF_TYPE];
 
-    const updateDate = useCallback(() => {
-      const actualValue = formObject[id] || formObject[id] === '' ? formObject[id].value : value;
+    useEffect(() => {
+      let actualValue = formObject[id] || formObject[id] === '' ? formObject[id].value : value;
+      actualValue = parseInitialValue(actualValue, type);
 
-      if (actualValue) {
-        setDate(new Date(actualValue));
-      }
+      setDate(actualValue);
     }, [formObject]);
 
     const onChange = useCallback(date => {
       let obj = {};
 
       /* User wants to remove the date */
-      if (!date) obj = { value: '', ...rest };
-      else obj = { value: date.toUTCString(), ...rest };
+      if (!date) {
+        obj = { value: '', ...rest };
+        setDate(null);
+        return;
+      }
 
+      /* assign the format to save based on the type */
+      if (type === UITypes.TimeField) obj.value = format(date, DATE_FORMAT.TIME);
+      if (type === UITypes.DateField) obj.value = format(date, DATE_FORMAT.DATE);
+      if (type === UITypes.DateTimeField) obj.value = date.toISOString();
+
+      obj = { ...obj, ...rest };
       modifyFormObject(id, obj);
       setDate(date);
     });
-
-    useEffect(() => {
-      updateDate();
-    }, [value, formObject]);
 
     /* set the date ranges based on the UI Element to display */
     let minDate;
@@ -86,9 +89,7 @@ const DateTimePicker = React.memo(
     }
     if (type === UITypes.DateTimeField) {
       /* min, max Values are datetimes and offset is in seconds */
-
       if (!Number.isNaN(mindatetimeOffset)) minDate = addSeconds(new Date(), mindatetimeOffset);
-
       if (!Number.isNaN(maxdatetimeOffset)) maxDate = addSeconds(new Date(), maxdatetimeOffset);
 
       /* min,maxValue take priority over the offsets if both values are provided */
@@ -99,7 +100,6 @@ const DateTimePicker = React.memo(
     }
     if (type === UITypes.DateField) {
       /* min,maxValue are dates and offset is in days */
-
       if (!Number.isNaN(mindateOffset)) minDate = addDays(new Date(), mindateOffset);
       if (!Number.isNaN(maxdateOffset)) maxDate = addDays(new Date(), maxdateOffset);
 
@@ -121,7 +121,11 @@ const DateTimePicker = React.memo(
       locale = `${locale[0]}`;
     }
 
-    registerLocale(locale, locales[locale]);
+    try {
+      registerLocale(locale, locales[locale]);
+    } catch (e) {
+      registerLocale(locale, locales.enUS);
+    }
 
     return (
       <FormModelConfig.Consumer>

--- a/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.test.js
+++ b/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.test.js
@@ -5,8 +5,39 @@ import 'jest-dom/extend-expect';
 
 afterAll(cleanup);
 
-describe('Provider Login Container', () => {
-  const { container } = render(<DateTimePicker />);
+describe('Time picker should render', () => {
+  const props = {
+    formObject: {},
+    value: '11:00:15'
+  };
+
+  const { container } = render(<DateTimePicker {...props} />);
+
+  it('shoud renders without crashing', () => {
+    expect(container).toBeTruthy();
+  });
+});
+
+describe('Date picker should render', () => {
+  const props = {
+    formObject: {},
+    value: '2011-06-06'
+  };
+
+  const { container } = render(<DateTimePicker {...props} />);
+
+  it('shoud renders without crashing', () => {
+    expect(container).toBeTruthy();
+  });
+});
+
+describe('Datetime picker should render', () => {
+  const props = {
+    formObject: {},
+    value: '2019-11-29T04:00:00.000Z'
+  };
+
+  const { container } = render(<DateTimePicker {...props} />);
 
   it('shoud renders without crashing', () => {
     expect(container).toBeTruthy();

--- a/src/lib/constants/index.js
+++ b/src/lib/constants/index.js
@@ -88,3 +88,9 @@ export const NotificationTypes = {
   UPDATE: 'https://www.w3.org/ns/activitystreams#Update',
   VIEW: 'https://www.w3.org/ns/activitystreams#View'
 };
+
+/* See <https://date-fns.org/v2.8.1/docs/format> for format explanations */
+export const DATE_FORMAT = {
+  DATE: 'yyyy-MM-dd',
+  TIME: 'kk:mm:ss'
+};

--- a/src/lib/utils/datestimes.test.js
+++ b/src/lib/utils/datestimes.test.js
@@ -1,4 +1,4 @@
-import { parseInitialValue } from './datetimes';
+import { parseInitialValue, isValidDate } from './datetimes';
 import { UITypes } from '@constants';
 
 describe('Parser should return the expected values', () => {
@@ -27,5 +27,23 @@ describe('Parser should return the expected values', () => {
 
   it('should parse datetimes correctly', () => {
     expect(parseInitialValue(dateTime, UITypes.DateTimeField)).toEqual(new Date(dateTime));
+  });
+});
+
+describe('Datetime checker should validate values', () => {
+  it('should validate now as a date', () => {
+    expect(isValidDate(new Date())).toEqual(true);
+  });
+
+  it('should fail with anything not a date object', () => {
+    expect(isValidDate('string')).toEqual(false);
+    expect(isValidDate(123)).toEqual(false);
+    expect(isValidDate({})).toEqual(false);
+    expect(isValidDate([new Date()])).toEqual(false);
+    expect(isValidDate({ date: new Date() })).toEqual(false);
+  });
+
+  it('should return false with a "Invalid date" Date object', () => {
+    expect(isValidDate(new Date('not a date representation'))).toBe(false);
   });
 });

--- a/src/lib/utils/datestimes.test.js
+++ b/src/lib/utils/datestimes.test.js
@@ -1,0 +1,31 @@
+import { parseInitialValue } from './datetimes';
+import { UITypes } from '@constants';
+
+describe('Parser should return the expected values', () => {
+  const time = '19:00:34';
+  const date = '2012-12-12';
+  const dateTime = '2019-11-29T04:00:00.000Z';
+
+  it('should parse times correctly', () => {
+    const [hours, minutes, seconds] = time.split(':').map(i => parseInt(i, 10));
+    const result = parseInitialValue(time, UITypes.TimeField);
+
+    expect(result.getHours()).toBe(hours);
+    expect(result.getMinutes()).toBe(minutes);
+    expect(result.getSeconds()).toBe(seconds);
+  });
+
+  it('should parse dates correctly', () => {
+    const [year, month, day] = date.split('-').map(i => parseInt(i, 10));
+    const result = parseInitialValue(date, UITypes.DateField);
+
+    expect(result.getFullYear()).toEqual(year);
+    // Months start at 0
+    expect(result.getMonth()).toEqual(month - 1);
+    expect(result.getDate()).toEqual(day);
+  });
+
+  it('should parse datetimes correctly', () => {
+    expect(parseInitialValue(dateTime, UITypes.DateTimeField)).toEqual(new Date(dateTime));
+  });
+});

--- a/src/lib/utils/datetimes.js
+++ b/src/lib/utils/datetimes.js
@@ -1,0 +1,37 @@
+import { addHours, setHours, setMinutes, setSeconds } from 'date-fns';
+import { UITypes } from '@constants';
+
+/**
+ * @param value - object stored in the pod
+ * @param type - one of UITypes[TimeField, DateField, DateTimeField]
+ * @returns {Date} - local datetime for the given string
+ */
+export const parseInitialValue = (value: string, type: string): Date => {
+  if (type === UITypes.TimeField) {
+    const tokens = value.split(':');
+
+    let date = new Date();
+    date = setHours(date, tokens[0]);
+    date = setMinutes(date, tokens[1]);
+    date = setSeconds(date, tokens[2]);
+
+    return date;
+  }
+  if (type === UITypes.DateField) {
+    /* date constructor interprets `value` as a UTC time, instead of a local time.
+      To convert that we apply the offset in hours.
+     */
+    const date = new Date(value);
+    const offset = date.getTimezoneOffset();
+    return addHours(date, offset / 60);
+  }
+  if (type === UITypes.DateTimeField) return new Date(value);
+};
+
+/**
+ * @returns {string} - the browser-set locale
+ */
+export const getLocale = (): string => {
+  if (navigator.languages !== undefined) return navigator.languages[0];
+  return navigator.language ? navigator.language : 'en-US';
+};

--- a/src/lib/utils/datetimes.js
+++ b/src/lib/utils/datetimes.js
@@ -21,11 +21,30 @@ export const parseInitialValue = (value: string, type: string): Date => {
     /* date constructor interprets `value` as a UTC time, instead of a local time.
       To convert that we apply the offset in hours.
      */
-    const date = new Date(value);
+    let date = new Date(value);
     const offset = date.getTimezoneOffset();
-    return addHours(date, offset / 60);
+
+    date = addHours(date, offset / 60);
+    return date;
   }
-  if (type === UITypes.DateTimeField) return new Date(value);
+  if (type === UITypes.DateTimeField) {
+    return new Date(value);
+  }
+
+  throw new Error(`Error: Unsupported type: ${type}`);
+};
+
+/**
+ * @param value: value to check
+ * @returns {boolean} true if @value is a Date object and not "Invalid date"
+ */
+export const isValidDate = (value: any): boolean => {
+  if (Object.prototype.toString.call(value) === '[object Date]') {
+    // see https://stackoverflow.com/a/1353711
+    return !Number.isNaN(value.getTime());
+  }
+  // Not a date
+  return false;
 };
 
 /**

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -2,7 +2,7 @@ import SolidError from './error';
 import * as shexUtil from './shex';
 import solidResponse from './statusMessage';
 import ShexFormValidator from './shexFormValidator';
-import { parseInitialValue, getLocale } from './datetimes';
+import { parseInitialValue, getLocale, isValidDate } from './datetimes';
 
 import {
   fetchSchema,
@@ -29,5 +29,6 @@ export {
   getFileName,
   getBasicPod,
   getLocale,
-  parseInitialValue
+  parseInitialValue,
+  isValidDate
 };

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -1,6 +1,9 @@
 import SolidError from './error';
 import * as shexUtil from './shex';
 import solidResponse from './statusMessage';
+import ShexFormValidator from './shexFormValidator';
+import { parseInitialValue, getLocale } from './datetimes';
+
 import {
   fetchSchema,
   existDocument,
@@ -8,16 +11,10 @@ import {
   fetchLdflexDocument,
   getBasicPod
 } from './solidFetch';
-import ShexFormValidator from './shexFormValidator';
 
 const getFileName = path => {
   // eslint-disable-next-line no-useless-escape
   return path.replace(/^.*[\\\/]/, '');
-};
-
-const getLocale = (): string => {
-  if (navigator.languages !== undefined) return navigator.languages[0];
-  return navigator.language ? navigator.language : 'en-US';
 };
 
 export {
@@ -31,5 +28,6 @@ export {
   ShexFormValidator,
   getFileName,
   getBasicPod,
-  getLocale
+  getLocale,
+  parseInitialValue
 };


### PR DESCRIPTION
This PR addresses: 

- Save format for the datepicker
- Data validation before save (fixed via https://github.com/inrupt/solid-sdk-forms/pull/25)