### PR TITLE
Fix off-by-one index error when checking if the locale has a second part

### DIFF
--- a/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.component.js
+++ b/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.component.js
@@ -119,7 +119,7 @@ const DateTimePicker = React.memo(
       locale[1] = locale[1].toUpperCase();
       locale = `${locale[0]}${locale[1]}`;
     } else {
-      locale = `${locale[1]}`;
+      locale = `${locale[0]}`;
     }
 
     try {

--- a/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.component.js
+++ b/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.component.js
@@ -115,12 +115,14 @@ const DateTimePicker = React.memo(
        browser format samples: 'es', 'en-US', 'en-GB'
        date-fns format samples: 'es', 'enUS', 'enGB' */
     let locale = getLocale().split('-');
-    if (locale[2]) {
-      locale[2] = locale[2].toUpperCase();
-      locale = `${locale[0]}${locale[2]}`;
+    if (locale[1]) {
+      locale[1] = locale[1].toUpperCase();
+      locale = `${locale[0]}${locale[1]}`;
     } else {
-      locale = `${locale[0]}`;
+      locale = `${locale[1]}`;
     }
+    console.log(getLocale().split('-'));
+    console.log(locale);
 
     try {
       registerLocale(locale, locales[locale]);

--- a/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.component.js
+++ b/src/lib/components/FormModel/children/Form/UI/DateTimePicker/date-time-picker.component.js
@@ -121,8 +121,6 @@ const DateTimePicker = React.memo(
     } else {
       locale = `${locale[1]}`;
     }
-    console.log(getLocale().split('-'));
-    console.log(locale);
 
     try {
       registerLocale(locale, locales[locale]);


### PR DESCRIPTION
Before all the locales that had the format "xx_XX" were reduced to "xx". This fixes this issue. 