### PR TITLE
Removing an extraneous check for the 'running' property. This incorre…

### DIFF
--- a/src/lib/components/FormModel/children/Group/group.component.js
+++ b/src/lib/components/FormModel/children/Group/group.component.js
@@ -32,7 +32,7 @@ export const Group = (props: Props) => {
         const componentData = type === VOCAB.UI.Group ? part[UI.PARTS] : part;
 
         let Indicator = () => null;
-        if (savingData.running && savingThis) Indicator = savingData.autosaveIndicator;
+        if (savingData && savingThis) Indicator = savingData.autosaveIndicator;
 
         return (
           <div key={name}>


### PR DESCRIPTION
…ctly only showed the autosave indicator if a save was in progress. We need the autosave indicator to show anytime a save was triggered, including if it ran and failed but is no longer running.