### PR TITLE
Updating Comment component to show properly

### DIFF
--- a/src/lib/components/FormModel/children/Form/UI/Comment/comment.component.js
+++ b/src/lib/components/FormModel/children/Form/UI/Comment/comment.component.js
@@ -9,7 +9,7 @@ type Props = {
 
 export const Comment = (props: Props) => {
   const { data } = props;
-  const { [UI.VALUE]: comment } = data;
+  const { [UI.CONTENTS]: comment } = data;
 
   const { theme } = useContext(ThemeContext);
 

--- a/src/lib/constants/index.js
+++ b/src/lib/constants/index.js
@@ -30,7 +30,8 @@ export const VOCAB = {
     TriStateField: 'http://www.w3.org/ns/ui#TriStateField',
     Multiple: 'http://www.w3.org/ns/ui#Multiple',
     Group: 'http://www.w3.org/ns/ui#Group',
-    Classifier: 'http://www.w3.org/ns/ui#Classifier'
+    Classifier: 'http://www.w3.org/ns/ui#Classifier',
+    Comment: 'http://www.w3.org/ns/ui#Comment'
   }
 };
 


### PR DESCRIPTION
Two significant changes in this commit:

* Added a constant that was being referenced but wasn't defined yet
* Pulled the value to show from UI.CONTENTS instead of UI.VALUE. This is defined in the Form Language, but Comments and Headers use ui:contents predicate instead of ui:value like other fields, as they are read-only fields.