### PR TITLE
Fixing bug related to Multiple component CSS class application

### DIFF
--- a/src/lib/components/FormModel/children/Viewer/UI/MultipleViewer/multiple-viewer.component.js
+++ b/src/lib/components/FormModel/children/Viewer/UI/MultipleViewer/multiple-viewer.component.js
@@ -39,7 +39,7 @@ export const MultipleViewer = (props: Props) => {
   }
 
   return (
-    <div id={key} key={key}>
+    <div id={key} className={classes} key={key}>
       <p>{label}</p>
       {parts.map(item => {
         // Fetch the name from the object for a unique key

--- a/src/lib/components/FormModel/children/Viewer/viewer.component.js
+++ b/src/lib/components/FormModel/children/Viewer/viewer.component.js
@@ -28,7 +28,7 @@ const Viewer = (props: Props) => {
   }, [formModel]);
 
   return (
-    <Group parent={parent} className={parent && theme && theme.childGroup}>
+    <Group parent={parent} className={formModel[UI.PART] && theme && theme.childGroup}>
       {formModel['dc:title'] && <h2>{formModel['dc:title']}</h2>}
       {formFields.length > 0 &&
         formFields.map(item => {


### PR DESCRIPTION
For Multiples and Groups, we only want the parent Group to apply the given class, not all children. A condition was added to the class declaration checking for ui:part, which is only present for parent Multiples. This eliminates unexpected nested class declarations.