### PR TITLE
Fixing form object creation error handling

### DIFF
--- a/src/lib/components/FormModel/form-model.component.js
+++ b/src/lib/components/FormModel/form-model.component.js
@@ -150,10 +150,15 @@ export const FormModel = (props: FormProps) => {
 
   /* Create a new model if any of the sources changes */
   useEffect(() => {
-    formUi.convertFormModel(modelSource, dataSource).then(model => {
-      setFormModel(model);
-      if (onLoaded) onLoaded();
-    });
+    formUi
+      .convertFormModel(modelSource, dataSource)
+      .then(model => {
+        setFormModel(model);
+        if (onLoaded) onLoaded();
+      })
+      .catch(err => {
+        onError(err);
+      });
   }, [modelSource, dataSource]);
 
   useEffect(() => {


### PR DESCRIPTION
Previously, the try/catch block around the form object creation function, called on form initialization, was not firing properly. Upon investigation it looks like the try/catch was not the proper way of catching the error, as it is an async function. Using .catch() instead worked to properly handle errors coming from the form library.