### PR TITLE
Fixing issue with missing classes for some components

### DIFF
--- a/src/lib/components/FormModel/children/Group/group.component.js
+++ b/src/lib/components/FormModel/children/Group/group.component.js
@@ -1,6 +1,6 @@
-import React from 'react';
-
-import { UI, RDF, UITypes, VOCAB } from '@constants';
+import React, { useContext } from 'react';
+import { ThemeContext } from '@context';
+import { UI, RDF, VOCAB } from '@constants';
 
 type Props = {
   data: object,
@@ -18,9 +18,10 @@ type Props = {
 
 export const Group = (props: Props) => {
   const { data, updateData, mapper, savingData, addNewField, deleteField } = props;
+  const { theme } = useContext(ThemeContext);
 
   return (
-    <div>
+    <div className={theme && theme.groupField}>
       {Object.entries(data).map(([, part]) => {
         const { [RDF.TYPE]: type, [UI.NAME]: name } = part;
         const Component = mapper[type];

--- a/src/lib/components/FormModel/children/Multiple/multiple.component.js
+++ b/src/lib/components/FormModel/children/Multiple/multiple.component.js
@@ -34,34 +34,29 @@ export const Multiple = (props: Props) => {
     });
   }
 
-  // Quick and dirty setup of custom classes.
-  // TODO: Refactor this
-  let classes = '';
-  if (theme) {
-    if (theme.form) {
-      classes += theme.form;
-    }
-    if (theme.childGroup) {
-      if (classes.length > 0) {
-        classes += ' ';
-      }
-      classes += theme.childGroup;
-    }
-  }
-
   return (
-    <div id={id} className={classes} key={id}>
+    <div id={id} className={theme && theme.multipleField} key={id}>
       <p>{label}</p>
       {parts.map(item => {
         // Fetch the name from the object for a unique key
         const key = item[UI.NAME];
         const type = VOCAB.UI.Group;
+
+        // For now we only support Multiples containing Groups. Once that restriction goes away we need more checks
+        // to see if the type is a part or another Component. This groupParts is a temporary fix until we add support
+        // for more Component types in Multiples
+        const groupPartsKey = Object.keys(item[UI.PARTS])[0];
+        const groupParts = item[UI.PARTS][groupPartsKey][UI.PARTS];
+
+        // If the group doesn't contain parts, exit gracefully. This shouldn't get hit with a valid form model.
+        if (!groupParts) {
+          return <div />;
+        }
         return (
-          <div key={key} className={classes}>
+          <div key={key}>
             <Group
-              className={theme && theme.childGroup}
               {...{
-                data: item[UI.PARTS],
+                data: groupParts,
                 updateData,
                 mapper,
                 savingData

--- a/src/lib/components/FormModel/children/Viewer/UI/MultipleViewer/multiple-viewer.component.js
+++ b/src/lib/components/FormModel/children/Viewer/UI/MultipleViewer/multiple-viewer.component.js
@@ -23,23 +23,8 @@ export const MultipleViewer = (props: Props) => {
     });
   }
 
-  // Quick and dirty setup of custom classes.
-  // TODO: Refactor this
-  let classes = '';
-  if (theme) {
-    if (theme.form) {
-      classes += theme.form;
-    }
-    if (theme.childGroup) {
-      if (classes.length > 0) {
-        classes += ' ';
-      }
-      classes += theme.childGroup;
-    }
-  }
-
   return (
-    <div id={key} className={classes} key={key}>
+    <div id={key} className={theme && theme.multipleField} key={key}>
       <p>{label}</p>
       {parts.map(item => {
         // Fetch the name from the object for a unique key
@@ -48,7 +33,7 @@ export const MultipleViewer = (props: Props) => {
           <div key={key}>
             <Viewer
               {...{
-                formModel: item,
+                formModel: item[UI.PARTS][Object.keys(item[UI.PARTS])[0]],
                 parent
               }}
             />

--- a/src/lib/components/FormModel/children/Viewer/viewer.component.js
+++ b/src/lib/components/FormModel/children/Viewer/viewer.component.js
@@ -28,7 +28,7 @@ const Viewer = (props: Props) => {
   }, [formModel]);
 
   return (
-    <Group parent={parent} className={formModel[UI.PART] && theme && theme.childGroup}>
+    <Group parent={parent} className={theme && theme.groupField}>
       {formModel['dc:title'] && <h2>{formModel['dc:title']}</h2>}
       {formFields.length > 0 &&
         formFields.map(item => {
@@ -45,6 +45,7 @@ const Viewer = (props: Props) => {
            * this avoid to crash app using recursive component
            */
           if (!field) return null;
+
           /* eslint no-useless-computed-key: "off" */
           const { ['ui:parts']: deleted, ...updatedField } = field;
 


### PR DESCRIPTION
Multiple and Group components were previously rendering incorrectly. This is part of a refactor where some class names changed, but are now tied more directly to Multiple and Group components instead of relying on child elements. This also allows a more consistent look and feel.

Classes were added for group and multiple fields, and added to both the edit and view components