### PR TITLE
Fixed WebID login bug

### DIFF
--- a/src/lib/components/ProviderLogin/provider-login.container.js
+++ b/src/lib/components/ProviderLogin/provider-login.container.js
@@ -69,7 +69,6 @@ export default class LoginComponent extends Component<Props> {
       e.preventDefault();
 
       const { idp, withWebId } = this.state;
-
       const { callbackUri, errorsText } = this.props;
 
       if (!idp) {
@@ -86,8 +85,7 @@ export default class LoginComponent extends Component<Props> {
       // necessarily the same as their Pod provider, the WebId might not coincide
       // match the IdP IRI. That is why getIdpFromWebId is required.
       const provider = withWebId ? await getIdpFromWebId(idp) : idp;
-
-      if (provider === null) {
+      if (!provider) {
         throw new SolidError(errorsText.noIdpForWebId, 'noIdpForWebId');
       }
 

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -15,7 +15,8 @@ import {
   existDocument,
   createDocument,
   fetchLdflexDocument,
-  getBasicPod
+  getBasicPod,
+  getIdpFromWebId
 } from './solidFetch';
 
 const getFileName = path => {
@@ -38,5 +39,6 @@ export {
   parseInitialValue,
   isValidDate,
   getFormattedLocale,
-  getClosestLocale
+  getClosestLocale,
+  getIdpFromWebId
 };

--- a/src/lib/utils/solidFetch.js
+++ b/src/lib/utils/solidFetch.js
@@ -97,7 +97,6 @@ export const getIdpFromWebId = async webId => {
       const idpConfigUrl = `${new URL(webId).origin}/.well-known/openid-configuration`;
       // TODO: This could be parallelized
       const issuer = await data[webId]['solid:oidcIssuer'];
-      console.log(`issuer: ${issuer}`);
       const idpConfig = await auth.fetch(idpConfigUrl);
 
       if (issuer) {
@@ -107,7 +106,6 @@ export const getIdpFromWebId = async webId => {
         idp = webId;
       }
     }
-    console.log(`The IdP for ${webId} is ${idp}`);
     return idp;
   } catch (e) {
     console.error(e);

--- a/src/lib/utils/solidFetch.js
+++ b/src/lib/utils/solidFetch.js
@@ -90,6 +90,30 @@ export const getBasicPod = async webId => {
   }
 };
 
+export const getIdpFromWebId = async webId => {
+  try {
+    let idp = null;
+    if (webId) {
+      const idpConfigUrl = `${new URL(webId).origin}/.well-known/openid-configuration`;
+      // TODO: This could be parallelized
+      const issuer = await data[webId]['solid:oidcIssuer'];
+      console.log(`issuer: ${issuer}`);
+      const idpConfig = await auth.fetch(idpConfigUrl);
+
+      if (issuer) {
+        // TODO: investigate why just assigning issuer to idp fails in the login process
+        idp = `${issuer}`;
+      } else if (idpConfig.ok) {
+        idp = webId;
+      }
+    }
+    console.log(`The IdP for ${webId} is ${idp}`);
+    return idp;
+  } catch (e) {
+    console.error(e);
+  }
+};
+
 export const ensureSlash = (inputPath, needsSlash) => {
   const hasSlash = inputPath.endsWith('/');
   if (hasSlash && !needsSlash) {


### PR DESCRIPTION
The issue was that the login page made the assumption that the WebID was hosted on the same origin as the Identity Provider, which is not necessarily the case. This fix adds a check on the `solid:oidcIssuer` predicate in the Profile Document to get the Identity Provider address, while remaining backwards compatible by also testing the presence of the IdP at the WebID origin.