### PR TITLE
Fixing issue with idp-url  login

### DIFF
--- a/src/lib/utils/solidFetch.js
+++ b/src/lib/utils/solidFetch.js
@@ -102,10 +102,18 @@ export const getIdpFromWebId = async webId => {
   let idp = null;
   if (webId) {
     const idpConfigUrl = `${new URL(webId).origin}/.well-known/openid-configuration`;
+    let issuer;
     // TODO: likely due to https://github.com/comunica/comunica/issues/565,
     // the following line throws an error that is not a promise rejection,
     // and therefore which is not catched by an async try/catch block
-    const issuer = await data[webId]['solid:oidcIssuer'];
+    const fileRequest = await auth.fetch(webId, {
+      method: 'HEAD'
+    });
+
+    if (fileRequest.ok) {
+      issuer = await data[webId]['solid:oidcIssuer'];
+    }
+
     if (issuer) {
       // TODO: investigate why just assigning issuer to idp fails in the login process
       idp = `${issuer}`;

--- a/src/lib/utils/solidFetch.js
+++ b/src/lib/utils/solidFetch.js
@@ -104,8 +104,8 @@ export const getIdpFromWebId = async webId => {
     const idpConfigUrl = `${new URL(webId).origin}/.well-known/openid-configuration`;
     let issuer;
     // TODO: likely due to https://github.com/comunica/comunica/issues/565,
-    // the following line throws an error that is not a promise rejection,
-    // and therefore which is not catched by an async try/catch block
+    // this code first checks if the file exists before making a request. Otherwise,
+    // the request will fail and cannot be caught, halting code execution
     const fileRequest = await auth.fetch(webId, {
       method: 'HEAD'
     });


### PR DESCRIPTION
* Adding additional check to see if a file exists before attempting to use ldflex to get the oidc issuer. This is a workaround to the fact that if there is an HTTP error, like 404, then ldflex doesn't bubble the error up to us and the code halts. Now we only use ldflex if the file exists.