### PR TITLE
Bug fix where path and id were absent

### DIFF
--- a/src/lib/classes/notification.js
+++ b/src/lib/classes/notification.js
@@ -470,6 +470,16 @@ export class Notification {
         // Loop over resulting notifications
         for await (const notification of validNotifications) {
           let notificationData = {};
+
+          // For each notification, get the path and a unique identifier. The path comes from
+          // the subject, and each quad has a subject field, so the first quad is used
+          const path = notification[0].subject.value;
+          const id = path
+            .split('/')
+            .pop()
+            .split('.')[0];
+          notificationData = id !== '' ? { id, path, inboxName: currentInbox.inboxName } : {};
+
           // Loop over all predicates in the notification shape and parse out the key and value
           for (const field of this.schema[name].shape) {
             // Find the quad for this field


### PR DESCRIPTION
* Added back in extraneously removed code that generates a path, id, and inboxname from the validated notification data. Without this, the notifications cannot be clicked as there's no subject to set as read/unread